### PR TITLE
Tip 503

### DIFF
--- a/pltcl.c
+++ b/pltcl.c
@@ -45,10 +45,12 @@ PG_MODULE_MAGIC;
 	((TCL_MAJOR_VERSION > maj) || \
 	 (TCL_MAJOR_VERSION == maj && TCL_MINOR_VERSION >= min))
 
-/* Insist on Tcl >= 8.5 */
-#if !HAVE_TCL_VERSION(8,5)
-/* This extension uses Tcl_SetNotifier which requires Tcl 8.5 or later. */
-#error The PostgreSQL Tcl extension only supports Tcl 8.5 or later.
+/* Insist on Tcl >= 8.6 */
+#if !HAVE_TCL_VERSION(8,6)
+/* This extension uses Tcl_SetNotifier which requires Tcl 8.5 or later,
+ * and Tcl8.5 does not take consts in callback types such as (Tcl_SetTimerProc).
+ */
+#error The PostgreSQL pltcl extension only supports Tcl 8.6 or later.
 #endif
 
 /* define our text domain for translations */

--- a/pltcl.c
+++ b/pltcl.c
@@ -45,9 +45,10 @@ PG_MODULE_MAGIC;
 	((TCL_MAJOR_VERSION > maj) || \
 	 (TCL_MAJOR_VERSION == maj && TCL_MINOR_VERSION >= min))
 
-/* Insist on Tcl >= 8.4 */
-#if !HAVE_TCL_VERSION(8,4)
-#error PostgreSQL only supports Tcl 8.4 or later.
+/* Insist on Tcl >= 8.5 */
+#if !HAVE_TCL_VERSION(8,5)
+/* This extension uses Tcl_SetNotifier which requires Tcl 8.5 or later. */
+#error The PostgreSQL Tcl extension only supports Tcl 8.5 or later.
 #endif
 
 /* define our text domain for translations */

--- a/pltcl.c
+++ b/pltcl.c
@@ -50,11 +50,6 @@ PG_MODULE_MAGIC;
 #error PostgreSQL only supports Tcl 8.4 or later.
 #endif
 
-/* Hack to deal with Tcl 8.6 const-ification without losing compatibility */
-#ifndef CONST86
-#define CONST86
-#endif
-
 /* define our text domain for translations */
 #undef TEXTDOMAIN
 #define TEXTDOMAIN PG_TEXTDOMAIN("pltcl")
@@ -353,7 +348,7 @@ pltcl_FinalizeNotifier(ClientData clientData)
 }
 
 static void
-pltcl_SetTimer(CONST86 Tcl_Time *timePtr)
+pltcl_SetTimer(const Tcl_Time *timePtr)
 {
 }
 
@@ -379,7 +374,7 @@ pltcl_ServiceModeHook(int mode)
 }
 
 static int
-pltcl_WaitForEvent(CONST86 Tcl_Time *timePtr)
+pltcl_WaitForEvent(const Tcl_Time *timePtr)
 {
 	return 0;
 }


### PR DESCRIPTION
Prepare for Tcl 8.7 by removing no longer used compatibility macros.

Current requirements increased to Tcl 8.6 or later.